### PR TITLE
Add explicit string concatenation example in Match toString

### DIFF
--- a/src/Match.java
+++ b/src/Match.java
@@ -16,9 +16,9 @@ public class Match {
         this.awayScore = awayScore;
     }
 
+    // return homeTeam.name + " " + homeScore + " - " + awayScore + " " + awayTeam.name + "(" + date + ")";
+    // "Tigers 2 - 1 Eagles (12/09/2025)"
     public toString() {
-        // return homeTeam.name + " " + homeScore + " - " + awayScore + " " + awayTeam.name + "(" + date + ")";
-        // "Tigers 2 - 1 Eagles (12/09/2025)"
         return String.format("%s %d - %d %s (%s)", homeTeam.name, homeScore, awayScore, awayTeam.name, date);
     }
 }
@@ -39,9 +39,9 @@ public class Match {
         this.awayScore = awayScore;
     }
 
+    // return homeTeam.name + " " + homeScore + " - " + awayScore + " " + awayTeam.name + "(" + date + ")";
+    // "Tigers 2 - 1 Eagles (12/09/2025)"
     public toString() {
-        // return homeTeam.name + " " + homeScore + " - " + awayScore + " " + awayTeam.name + "(" + date + ")";
-        // "Tigers 2 - 1 Eagles (12/09/2025)"
         return String.format("%s %d - %d %s (%s)", homeTeam.name, homeScore, awayScore, awayTeam.name, date);
     }
 }


### PR DESCRIPTION
## Summary
- illustrate `Match.toString()` with comments showing explicit concatenation and sample output

## Testing
- `javac -d bin src/*.java` *(fails: invalid method declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68c534234c748330b48adaa71494d1f4